### PR TITLE
fix: #43 Use new tree api for collapse and expand

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,38 @@
+module.exports = {
+  env: {
+    es2021: true,
+    node: true
+  },
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  overrides: [
+    {
+      env: {
+        node: true
+      },
+      files: ['.eslintrc.{js,cjs}'],
+      parserOptions: {
+        sourceType: 'script'
+      }
+    }
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        args: 'all',
+        argsIgnorePattern: '^_',
+        caughtErrors: 'all',
+        caughtErrorsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        ignoreRestSiblings: true
+      }
+    ]
+  }
+};

--- a/src/provider/base.ts
+++ b/src/provider/base.ts
@@ -102,19 +102,19 @@ export abstract class ProviderBase {
     collapsed?: boolean
   ): void {
     if (collapsed === undefined) {
-      if (!leaf.view.toggleCollapseAll) {
+      if (!leaf.view.tree?.toggleCollapseAll) {
         console.error(
           `No toggle collapse function found on ${this.leafType} view.`
         );
         return;
       }
-      leaf.view.toggleCollapseAll();
+      leaf.view.tree?.toggleCollapseAll();
     } else {
-      if (!leaf.view.setCollapseAll) {
+      if (!leaf.view.tree?.setCollapseAll) {
         console.error(`No collapse function found on ${this.leafType} view.`);
         return;
       }
-      leaf.view.setCollapseAll(collapsed);
+      leaf.view.tree.setCollapseAll(collapsed);
     }
   }
 
@@ -125,7 +125,7 @@ export abstract class ProviderBase {
     const leaves = singleLeaf ? [singleLeaf] : this.leaves;
     let collapsed = true;
     for (const leaf of leaves) {
-      if (!leaf.view.isAllCollapsed) {
+      if (leaf.view.tree?.isAllCollapsed === undefined) {
         console.error('No collapsed state found on view.');
         collapsed = false;
       }

--- a/src/provider/bookmarks.ts
+++ b/src/provider/bookmarks.ts
@@ -1,4 +1,3 @@
-import { Command, WorkspaceLeaf } from 'obsidian';
 import { ProviderType } from '../constants';
 import { ProviderBase } from './base';
 
@@ -7,26 +6,6 @@ export class BookmarksProvider extends ProviderBase {
   public readonly displayName = 'Bookmarks';
   protected readonly leafType = 'bookmarks';
   protected readonly toggleCommandName = 'Toggle collapse in bookmarks view';
-  protected readonly collapseCommandName = 'Not available';
-  protected readonly expandCommandName = 'Not available';
-
-  protected override get commands(): Command[] {
-    return [this.toggleCommand];
-  }
-
-  public override allCollapsed(_?: WorkspaceLeaf): boolean {
-    return false;
-  }
-
-  public override collapseAll(): void {
-    // Not available
-  }
-
-  public override expandAll(): void {
-    // Not available
-  }
-
-  protected override collapseOrExpandAll(leaf: WorkspaceLeaf): void {
-    leaf.view.collapseOrExpandAllEl?.click();
-  }
+  protected readonly collapseCommandName = 'Collapse all in bookmarks view';
+  protected readonly expandCommandName = 'Expand all in bookmarks view';
 }

--- a/src/provider/search.ts
+++ b/src/provider/search.ts
@@ -17,4 +17,23 @@ export class SearchProvider extends ProviderBase {
   public override toggleCollapse(): void {
     // Not available
   }
+
+  /**
+   * Collapse or expand all items for the given leaf
+   * @argument collapsed if not provided, will toggle the state
+   */
+  protected collapseOrExpandAll(
+    leaf: WorkspaceLeaf,
+    collapsed?: boolean
+  ): void {
+    if (collapsed === undefined) {
+      // Not availabble
+    } else {
+      if (!leaf.view.setCollapseAll) {
+        console.error(`No collapse function found on ${this.leafType} view.`);
+        return;
+      }
+      leaf.view.setCollapseAll(collapsed);
+    }
+  }
 }

--- a/src/provider/tag-pane.ts
+++ b/src/provider/tag-pane.ts
@@ -1,4 +1,4 @@
-import { WorkspaceLeaf } from 'obsidian';
+import { Command, WorkspaceLeaf } from 'obsidian';
 import { ProviderType } from '../constants';
 import { ProviderBase } from './base';
 
@@ -6,16 +6,30 @@ export class TagPaneProvider extends ProviderBase {
   providerType: ProviderType = ProviderType.TagPane;
   displayName = 'Tag pane';
   protected leafType = 'tag';
-  protected readonly collapseCommandName =
-    'Collapse open tags in all tag explorers';
-  protected readonly expandCommandName =
-    'Expand closed tags in all tag explorers';
+  protected readonly collapseCommandName = 'Not available';
+  protected readonly expandCommandName = 'Not available';
   protected readonly toggleCommandName = 'Toggle collapse in all tag explorers';
+
+  protected override get commands(): Command[] {
+    return [this.toggleCommand];
+  }
 
   public override toggleCollapse(singleLeaf?: WorkspaceLeaf): void {
     const leaves = singleLeaf ? [singleLeaf] : this.leaves;
     for (const leaf of leaves) {
-      leaf.view.collapseOrExpandAllEl?.click();
+      if (!leaf.view.collapseOrExpandAllEl) {
+        console.error(`No collapse element found on ${this.leafType} view.`);
+        return;
+      }
+      leaf.view.collapseOrExpandAllEl.click();
     }
+  }
+
+  public override collapseAll(_?: WorkspaceLeaf | null): void {
+    // Not available
+  }
+
+  public override expandAll(_?: WorkspaceLeaf | null): void {
+    // Not available
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,15 @@
-// eslint-disable-next-line - Need at least one import so this compiles.
-import { View } from 'obsidian';
-
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { View } from 'obsidian';
 declare module 'obsidian' {
   interface View {
-    toggleCollapseAll: () => void;
-    setCollapseAll: (collapse: boolean) => void;
-    isAllCollapsed: boolean;
-    collapseOrExpandAllEl: HTMLDivElement;
+    tree?: {
+      toggleCollapseAll?: () => void;
+      setCollapseAll?: (collapse: boolean) => void;
+      isAllCollapsed?: boolean;
+    };
+    toggleCollapseAll?: () => void;
+    setCollapseAll?: (collapse: boolean) => void;
+    isAllCollapsed?: boolean;
+    collapseOrExpandAllEl?: HTMLDivElement;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,18 +5,12 @@
     "inlineSources": true,
     "module": "ESNext",
     "target": "es6",
-    "allowJs": true,
+    "allowJs": false,
     "noImplicitAny": true,
+    "strict": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "lib": [
-      "dom",
-      "es5",
-      "scripthost",
-      "es2015"
-    ]
+    "lib": ["dom", "es5", "scripthost", "es2015"]
   },
-  "include": [
-    "**/*.ts"
-  ]
+  "include": ["**/*.ts"]
 }


### PR DESCRIPTION
There were internal breaking changes to the Obsidian api. Updated each provider with its current state.

Closes: #43
